### PR TITLE
fix: 그룹 생성 규칙 수 30자 제한 및 토스트메세지 노출

### DIFF
--- a/project_today/lib/ui/organisms/bottomSheet.dart
+++ b/project_today/lib/ui/organisms/bottomSheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:project_today/ui/atoms/customToast.dart';
 
 //TODO 바텀시트 자체만 두고, 기능 내용은 위에서 관리해야 할듯
 
@@ -22,6 +23,12 @@ class BottomSheetWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    ruleController.addListener(() {
+      if (ruleController.text.length >= 30) {
+        _showToast(context, "최대 30자만 입력할 수 있어요");
+      }
+    });
+
     return Padding(
       padding: EdgeInsets.only(
         bottom: MediaQuery.of(context).viewInsets.bottom + 20,
@@ -59,6 +66,7 @@ class BottomSheetWidget extends StatelessWidget {
                   controller: ruleController,
                   focusNode: focusNode,
                   autofocus: true,
+                  maxLength: 30,
                   decoration: InputDecoration(
                     hintText: "30자 이내로 입력해 주세요",
                     hintStyle: TextStyle(
@@ -70,6 +78,7 @@ class BottomSheetWidget extends StatelessWidget {
                       borderRadius: BorderRadius.circular(14),
                       borderSide: BorderSide.none,
                     ),
+                    counterText: "",
                   ),
                   onFieldSubmitted: (value) {
                     if (value.isNotEmpty) {
@@ -85,5 +94,33 @@ class BottomSheetWidget extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  void _showToast(BuildContext context, String message) {
+    final overlay = Overlay.of(context);
+    final overlayEntry = OverlayEntry(builder: (context) {
+      double bottomOffset = MediaQuery.of(context).viewInsets.bottom + 180.0;
+
+      return Positioned(
+        bottom: bottomOffset,
+        left: 0,
+        right: 0,
+        child: Align(
+          alignment: Alignment.center,
+          child: Material(
+            color: Colors.transparent,
+            child: CustomToast(
+              text: message,
+              type: ToastType.NEGATIVE,
+            ),
+          ),
+        ),
+      );
+    });
+
+    overlay?.insert(overlayEntry);
+    Future.delayed(const Duration(seconds: 3), () {
+      overlayEntry.remove();
+    });
   }
 }


### PR DESCRIPTION
## 📌 이슈

- Resolves #88 

## 🙋🏻‍♂️ 어떤 PR인가요?

- 그룹 생성 규칙 수 30자 제한 및 토스트메세지 노출
- 바텀시트 위에 토스트메세지 노출되게 함
- [refactor/#76_group]브랜치에 구현하다가 꼬여서 브랜치 새로 팠는데! 해당 브랜치는 더 이상 쓰지 않기로 해요 ..... 헤헤 🥲

## ✅ Check List

- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
- [x] 적절한 라벨 설정
- [x] PR에 해당되는 Issue를 연결 완료
